### PR TITLE
Add (compact) unwind info parsers for arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ refuse to load your hand-crafter binary, or you just like looking at Mach-O diss
 ## Usage
 
 ```
-zacho --help
-zacho [-hldc] [--help] [--verify-memory-layout] <FILE>
+zacho [-hlducv] [--help] [--verify-memory-layout] <FILE>
         --help
             Display this help and exit.
 
@@ -25,11 +24,17 @@ zacho [-hldc] [--help] [--verify-memory-layout] <FILE>
     -d, --dyld-info
             Print the contents of dyld rebase and bind opcodes.
 
+    -u, --unwind-info
+            Print the contents of (compact) unwind info section (if any).
+
     -c, --code-signature
             Print the contents of code signature (if any).
 
         --verify-memory-layout
             Print virtual memory layout and verify there is no overlap.
+
+    -v, --verbose
+            Print more detailed info for each flag (if available).
 ```
 
 Currently, `zacho` will let you print parsed Mach-O header, and print formatted load commands.

--- a/src/ZachO.zig
+++ b/src/ZachO.zig
@@ -582,6 +582,14 @@ pub fn printUnwindInfo(self: ZachO, writer: anytype) !void {
                 .prefix = 12,
             });
         }
+    } else {
+        const sect = self.getSectionByName("__TEXT", "__unwind_info") orelse {
+            try writer.writeAll("No __TEXT,__unwind_info section found.\n");
+            return;
+        };
+
+        const data = self.data[sect.offset..][0..sect.size];
+        std.log.warn("{x}", .{std.fmt.fmtSliceHexLower(data)});
     }
 }
 
@@ -596,7 +604,7 @@ fn formatCompactUnwindEncodingArm64(enc: unwind_arm64_encoding, writer: anytype,
 
     switch (enc) {
         .frameless => |frameless| {
-            try writer.print(prefix ++ "{s: <12} 0x{x:0>8}\n", .{ "stack size:", frameless.stack_size });
+            try writer.print(prefix ++ "{s: <12} {d}\n", .{ "stack size:", frameless.stack_size * 16 });
         },
         .frame => |frame| {
             inline for (@typeInfo(@TypeOf(frame.x_reg_pairs)).Struct.fields) |field| {

--- a/src/ZachO.zig
+++ b/src/ZachO.zig
@@ -668,7 +668,20 @@ pub fn printUnwindInfo(self: ZachO, writer: anytype) !void {
                         *align(1) const macho.unwind_info_regular_second_level_page_header,
                         data.ptr + start_offset,
                     ).*;
-                    std.log.warn("{}", .{page_header});
+
+                    var pos = start_offset + page_header.entryPageOffset;
+                    var count: usize = 0;
+                    while (count < page_header.entryCount) : (count += 1) {
+                        const inner = @ptrCast(
+                            *align(1) const macho.unwind_info_regular_second_level_entry,
+                            data.ptr + pos,
+                        ).*;
+                        try writer.print("      [{d}]: function offset=0x{x:0>8}, encoding=0x{x:0>8}\n", .{
+                            count,
+                            inner.functionOffset,
+                            inner.encoding,
+                        });
+                    }
                 },
                 .COMPRESSED => {
                     const page_header = @ptrCast(

--- a/src/ZachO.zig
+++ b/src/ZachO.zig
@@ -695,14 +695,21 @@ pub fn printUnwindInfo(self: ZachO, writer: anytype) !void {
 
         try writer.writeAll("\n  LSDAs:\n");
         for (lsdas) |lsda, i| {
+            const func_sym = self.findSymbolByAddress(seg.vmaddr + lsda.functionOffset);
+            const func_name = self.getString(func_sym.n_strx);
+            const lsda_sym = self.findSymbolByAddress(seg.vmaddr + lsda.lsdaOffset);
+            const lsda_name = self.getString(lsda_sym.n_strx);
+
             try writer.print("    LSDA {d}\n", .{i});
-            try writer.print("      {s: <20} 0x{x}\n", .{
+            try writer.print("      {s: <20} 0x{x} {s}\n", .{
                 "Function offset:",
                 lsda.functionOffset,
+                func_name,
             });
-            try writer.print("      {s: <20} 0x{x}\n", .{
+            try writer.print("      {s: <20} 0x{x} {s}\n", .{
                 "LSDA offset:",
                 lsda.lsdaOffset,
+                lsda_name,
             });
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,6 +15,7 @@ pub fn main() !void {
         clap.parseParam("-h, --header           Print the Mach-O header.") catch unreachable,
         clap.parseParam("-l, --load-commands    Print load commands.") catch unreachable,
         clap.parseParam("-d, --dyld-info        Print the contents of dyld rebase and bind opcodes.") catch unreachable,
+        clap.parseParam("-u, --unwind-info      Print the contents of (compact) unwind info section (if any).") catch unreachable,
         clap.parseParam("-c, --code-signature   Print the contents of code signature (if any).") catch unreachable,
         clap.parseParam("--verify-memory-layout Print virtual memory layout and verify there is no overlap.") catch unreachable,
         clap.parseParam("<FILE>") catch unreachable,
@@ -53,6 +54,9 @@ pub fn main() !void {
     }
     if (res.args.@"dyld-info") {
         try zacho.printDyldInfo(stdout);
+    }
+    if (res.args.@"unwind-info") {
+        try zacho.printUnwindInfo(stdout);
     }
     if (res.args.@"code-signature") {
         try zacho.printCodeSignature(stdout);

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,6 +18,7 @@ pub fn main() !void {
         clap.parseParam("-u, --unwind-info      Print the contents of (compact) unwind info section (if any).") catch unreachable,
         clap.parseParam("-c, --code-signature   Print the contents of code signature (if any).") catch unreachable,
         clap.parseParam("--verify-memory-layout Print virtual memory layout and verify there is no overlap.") catch unreachable,
+        clap.parseParam("-v, --verbose          Print more detailed info for each flag (if available).") catch unreachable,
         clap.parseParam("<FILE>") catch unreachable,
     };
 
@@ -43,7 +44,7 @@ pub fn main() !void {
     const file = try std.fs.cwd().openFile(filename, .{});
     defer file.close();
 
-    var zacho = try ZachO.parse(gpa.allocator(), file);
+    var zacho = try ZachO.parse(gpa.allocator(), file, res.args.verbose);
     defer zacho.deinit();
 
     if (res.args.header) {


### PR DESCRIPTION
ZachO now supports parsing and pretty printing:
* `__LD,__compact_unwind` section contents found in relocatables
* `__TEXT,__unwind_info` section contents found in final linked images

It can dump the contents in two ways: 
* compactly by appending `-u` flag only which will print the contents similarly to how `objdump` does it

```
❯ zacho a.out -u        
Contents of __TEXT,__unwind_info section:
  Version:                  1
  Common encodings offset:  0x1c
  Common encodings count:   2
  Personalities offset:     0x24
  Personalities count:      0
  Indexes offset:           0x24
  Indexes count:            2

  Common encodings: (count = 2)
    encoding[0]: 0x03000038
    encoding[1]: 0x03000014

  Personality functions: (count = 0)

  Top level indices: (count = 2)
    [0]: function offset=0x00000480, 2nd level page offset=0x0000003c, LSDA offset=0x0000003c
    [1]: function offset=0x000004f8, 2nd level page offset=0x00000000, LSDA offset=0x0000003c

  LSDA descriptors:

  Second level indices:
    Second level index[0]: offset in section=0x0000003c, base function offset=0x00000480
      [0]: function offset=0x00000480, encoding[1]=0x03000014
      [1]: function offset=0x000004c0, encoding[0]=0x03000038
```

* verbosely by appending `-u -v` flags which will print the contents by working out symbol addresses, names, and following GOT indirection, and fully parsing the unwind info encoding values

```
❯ zacho a.out -u -v
Contents of __TEXT,__unwind_info section:
  Version:                  1
  Common encodings offset:  0x1c
  Common encodings count:   2
  Personalities offset:     0x24
  Personalities count:      0
  Indexes offset:           0x24
  Indexes count:            2

  Common encodings: (count = 2)
    encoding[0]
      start:       false
      LSDA:        false
      personality: 0
      mode:        dwarf
      FDE offset:  0x00000038
    encoding[1]
      start:       false
      LSDA:        false
      personality: 0
      mode:        dwarf
      FDE offset:  0x00000014

  Personality functions: (count = 0)

  Top level indices: (count = 2)
    [0] __Z3addii
      Function address:    0x0000000100000480
      Second level pages:  0x0000003c
      LSDA index array:    0x0000003c
    [1] _main
      Function address:    0x00000001000004f8
      Second level pages:  0x00000000
      LSDA index array:    0x0000003c

  LSDA descriptors:

  Second level indices:
    Second level index[0]: __Z3addii
      Offset in section: 0x0000003c
      Function address: 0x0000000100000480
      [0] __Z3addii
        Function address: 0x0000000100000480
        Encoding
          start:       false
          LSDA:        false
          personality: 0
          mode:        dwarf
          FDE offset:  0x00000014
      [1] _main
        Function address: 0x00000001000004c0
        Encoding
          start:       false
          LSDA:        false
          personality: 0
          mode:        dwarf
          FDE offset:  0x00000038
```