### PR TITLE
Dump symbol table if exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ refuse to load your hand-crafter binary, or you just like looking at Mach-O diss
 ## Usage
 
 ```
-zacho [-hlducv] [--help] [--verify-memory-layout] <FILE>
+zacho [-cdhlsuv] [--help] [--verify-memory-layout] <FILE>
         --help
             Display this help and exit.
+
+    -c, --code-signature
+            Print the contents of code signature (if any).
+
+    -d, --dyld-info
+            Print the contents of dyld rebase and bind opcodes.
 
     -h, --header
             Print the Mach-O header.
@@ -21,20 +27,17 @@ zacho [-hlducv] [--help] [--verify-memory-layout] <FILE>
     -l, --load-commands
             Print load commands.
 
-    -d, --dyld-info
-            Print the contents of dyld rebase and bind opcodes.
+    -s, --symbol-table
+            Print the symbol table.
 
     -u, --unwind-info
             Print the contents of (compact) unwind info section (if any).
 
-    -c, --code-signature
-            Print the contents of code signature (if any).
+    -v, --verbose
+            Print more detailed info for each flag (if available).
 
         --verify-memory-layout
             Print virtual memory layout and verify there is no overlap.
-
-    -v, --verbose
-            Print more detailed info for each flag (if available).
 ```
 
 Currently, `zacho` will let you print parsed Mach-O header, and print formatted load commands.

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,13 +12,14 @@ pub fn main() !void {
 
     const params = comptime [_]clap.Param(clap.Help){
         clap.parseParam("--help                 Display this help and exit.") catch unreachable,
+        clap.parseParam("-c, --code-signature   Print the contents of code signature (if any).") catch unreachable,
+        clap.parseParam("-d, --dyld-info        Print the contents of dyld rebase and bind opcodes.") catch unreachable,
         clap.parseParam("-h, --header           Print the Mach-O header.") catch unreachable,
         clap.parseParam("-l, --load-commands    Print load commands.") catch unreachable,
-        clap.parseParam("-d, --dyld-info        Print the contents of dyld rebase and bind opcodes.") catch unreachable,
+        clap.parseParam("-s, --symbol-table     Print the symbol table.") catch unreachable,
         clap.parseParam("-u, --unwind-info      Print the contents of (compact) unwind info section (if any).") catch unreachable,
-        clap.parseParam("-c, --code-signature   Print the contents of code signature (if any).") catch unreachable,
-        clap.parseParam("--verify-memory-layout Print virtual memory layout and verify there is no overlap.") catch unreachable,
         clap.parseParam("-v, --verbose          Print more detailed info for each flag (if available).") catch unreachable,
+        clap.parseParam("--verify-memory-layout Print virtual memory layout and verify there is no overlap.") catch unreachable,
         clap.parseParam("<FILE>") catch unreachable,
     };
 
@@ -64,6 +65,9 @@ pub fn main() !void {
     }
     if (res.args.@"verify-memory-layout") {
         try zacho.verifyMemoryLayout(stdout);
+    }
+    if (res.args.@"symbol-table") {
+        try zacho.printSymbolTable(stdout);
     }
 }
 


### PR DESCRIPTION
ZachO can now dump the symbol table formatted using `nm`'s Darwin style:

```
❯ zacho a.out -s

Symbol table:
  0x00000001000004c0 (__TEXT,__text) external _main
  0x0000000100000480 (__TEXT,__text) external __Z3addii
  0x0000000100000000 (__TEXT,__text) [referenced dynamically] external __mh_execute_header
                     (undefined) external dyld_stub_binder (from libSystem)
```

```
❯ zacho a.o -s          

Symbol table:
  0x0000000000000000 (__TEXT,__text) non-external ltmp0
  0x000000000000005c (__TEXT,__cstring) non-external ltmp1
  0x000000000000005c (__TEXT,__cstring) non-external l_.src
  0x0000000000000060 (__TEXT,__const) non-external ltmp2
  0x0000000000000060 (__TEXT,__const) non-external l___unnamed_1
  0x0000000000000000 (__TEXT,__text) external _add_to_i_and_j
  0x0000000000000004 (common) (alignment 2^2) external _i
  0x0000000000000004 (common) (alignment 2^2) external _j
```